### PR TITLE
chore: add landio-copy-087b2-main source folder

### DIFF
--- a/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/.github/workflows/ci.yml
+++ b/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: Build and release preview
+permissions:
+  contents: write
+
+on:
+  push:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  ci:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - id: framer
+        run: bun run framer
+        continue-on-error: true
+      - id: build
+        run: bun run build
+        continue-on-error: true
+      - id: deploy
+        run: bunx unframer-deploy-demo@latest --secret 5312773bf94446cb --slug landio-copy-087b2 --dir ./dist
+        continue-on-error: true
+      - name: Commit & push (if changed)
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+
+          git pull --rebase origin "${{ github.ref_name }}" || true
+          git commit -m "chore: automated update [skip ci]"
+          git push origin HEAD:"${{ github.ref_name }}" || true
+      - name: Auto-fix with OpenCode on failure
+        if: ${{ (steps.framer.outcome == 'failure' || steps.build.outcome == 'failure' || steps.deploy.outcome == 'failure') && !cancelled() }}
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_ZEN_API_KEY }}
+        run: |
+          npm install -g opencode-ai
+          opencode run --model opencode/kimi-k2 "The GitHub Actions workflow at .github/workflows/ci.yml just failed during CI. You are OpenCode running inside a post-failure handler with up to five minutes to work. Read the file at .github/workflows/ci.yml so you understand the steps and repeat them. Try to run those workflow steps again locally (bun run framer, bun run build, bunx unframer-deploy-demo), fix any issues that appear, rerun until they pass. If some imported files in App.tsx do not exist just remove them. After fixing and getting all steps to pass, commit and push the fixes just like the workflow does. Then exit with code 0 to mark the CI as successful. If you cannot fix the issues, exit with code 1."

--- a/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/.gitignore
+++ b/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/.gitignore
@@ -1,0 +1,11 @@
+
+node_modules
+dist
+.DS_Store
+.env
+.env.*
+.stackblitzrc
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+*.log

--- a/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/README.md
+++ b/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/README.md
@@ -1,0 +1,47 @@
+# landio (copy)
+
+This repo was exported from the Framer project "landio (copy)"
+
+This is just an example showcasing how to import the components and render them for your project. You will need to tweak a few styles and code to make the website look the same as Framer, for example changing the background color. You will also need to add other pages manually, following [App.tsx](./src/App.tsx) as an example.
+
+## Preview of your website
+
+An example preview of your website is already deployed [here](https://landio-copy-087b2-demos.unframer.co). If there are any styles issues like wrong background color you can easily fix it with a little bit of code. When you push new commits to this repository that website will be automatically updated.
+
+## Customizing styles and content
+
+The important code is inside [App.tsx](./src/App.tsx), it imports the Framer styles and your project React components. You can customize them using Tailwind classes and passing props, each Framer variable becomes a customizable React prop.
+
+To customize content you can also change the content directly in Framer and sync again. CMS content will need to run `npm run framer` to be synced with your code too.
+
+## Sync changes from Framer
+
+After you make changes inside the Framer project you can run again the command `npm run framer` to download the latest changes from your Framer project. If you add new components or pages you will also need to run the React Export plugin again first.
+
+## Development
+
+Install dependencies:
+```bash
+npm install
+```
+
+Generate component files from Framer:
+```bash
+npm run framer
+```
+
+Start development server:
+```bash
+npm run dev
+```
+
+## Project Structure
+
+The `package.json` `framer` script generates the React components in the `src/framer` folder. These files are machine generated and should not be updated manually, instead you can update the content directly in Framer and sync again. You can also use Framer variables to update content from code using React props. This works even for callbacks like `onClick`.
+
+The file [App.tsx](./src/App.tsx) contains an example generated component with your components, you can modify it to change the appearence of your website. You can also pass Framer variables using props.
+
+
+## More info
+
+You can read more documentation in [the Unframer repository](https://github.com/remorses/unframer)

--- a/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/index.html
+++ b/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/index.html
@@ -1,0 +1,13 @@
+
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Unframer + Vite + React + TS</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="module" src="/src/main.tsx"></script>
+    </body>
+</html>

--- a/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/package.json
+++ b/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "unframer-vite-react-typescript-starter",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "stackblitz": {
+    "startCommand": "STACKBLITZ_DEMO_EXAMPLE=src/App.tsx npm run framer && npm run dev"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "framer": "unframer 087b23b0dcc0828a --outDir src/framer"
+  },
+  "dependencies": {
+    "react": "latest",
+    "unframer": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {
+    "@types/react": "latest",
+    "@types/react-dom": "latest",
+    "@vitejs/plugin-react": "latest",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0",
+    "typescript": "latest",
+    "vite": "latest"
+  }
+}

--- a/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/postcss.config.js
+++ b/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/postcss.config.js
@@ -1,0 +1,7 @@
+
+export default {
+    plugins: {
+        tailwindcss: {},
+        autoprefixer: {},
+    }
+}

--- a/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/src/App.tsx
+++ b/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/src/App.tsx
@@ -1,0 +1,28 @@
+import './framer/styles.css'
+
+import CtaSectionFramerComponent from './framer/cta-section'
+import LogoBoxFramerComponent from './framer/logo-box'
+import AvailabilityFramerComponent from './framer/availability'
+import MainButtonFramerComponent from './framer/main-button'
+import SocialMediaFramerComponent from './framer/elements/social-media'
+
+export default function App() {
+  return (
+    <div className='flex flex-col items-center gap-3 bg-[rgb(4,_7,_13)]'>
+      <CtaSectionFramerComponent.Responsive/>
+      <LogoBoxFramerComponent.Responsive/>
+      <AvailabilityFramerComponent.Responsive
+        jn909WTNI={"NEW GEN AI AUTOMATION PARTNER"}
+        tCgMNdSJ8={"not available"}
+      />
+      <MainButtonFramerComponent.Responsive
+        WygjbYACO={"Book A Free Call"}
+        pkd7Pcy3s={true}
+        ypOX2jdFN={"https://framer.link/D4dc7gs"}
+      />
+      <SocialMediaFramerComponent.Responsive
+        YdTA2k7Lp={"https://x.com/home"}
+      />
+    </div>
+  );
+};

--- a/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/src/index.css
+++ b/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/src/main.tsx
+++ b/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/src/main.tsx
@@ -1,0 +1,9 @@
+
+import './index.css'
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+    <App />
+)

--- a/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/tailwind.config.js
+++ b/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/tailwind.config.js
@@ -1,0 +1,12 @@
+
+/** @type {import('tailwindcss').Config} */
+export default {
+    content: [
+        "./index.html",
+        "./src/**/*.{js,ts,jsx,tsx}",
+    ],
+    theme: {
+        extend: {},
+    },
+    plugins: [],
+}

--- a/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/tsconfig.json
+++ b/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": [
+      "ES2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/vite.config.ts
+++ b/apps/web/components/landio-copy-087b2-main/landio-copy-087b2-main/vite.config.ts
@@ -1,0 +1,8 @@
+
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+    plugins: [react()],
+})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Adds a new GitHub Actions workflow that runs on every push, deploys via `unframer-deploy-demo` using an embedded secret, and can auto-commit/push changes; this introduces supply-chain and repo-integrity risk if the workflow or external tools are compromised.
> 
> **Overview**
> Adds a new `landio-copy-087b2-main` Vite + React + TS + Tailwind project exported from Framer/Unframer, including a sample `App.tsx` wiring several generated Framer components and a `framer` sync script.
> 
> Introduces a repo-local GitHub Actions workflow that installs via Bun, runs `framer` + build + deploy to an Unframer demo site, auto-commits any generated changes back to the branch, and optionally invokes OpenCode to attempt automated fixes on CI failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae8bf829197d6b0e01dbb445bdc9ddfced7f9384. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->